### PR TITLE
add SIG meetings info in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ Maintainers ([@open-telemetry/ebpf-maintainers](https://github.com/orgs/open-tel
 - [Jonathan Perry](https://github.com/yonch), Splunk
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
+
+## Questions ##
+
+You can connect with us in our [slack channel](https://cloud-native.slack.com/archives/C02AB15583A).
+
+The OpenTelemetry eBPF special interest group (SIG) meets regularly, and the meetting is held every 
+week on Tuesday at 09:00 Pacific time.
+See the [eBPF Workgroup Meeting Notes](https://docs.google.com/document/d/13GK915hdDQ9sUYzUIWi4pOfJK68EE935ugutUgL3yOw) for a summary description of past meetings.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -221,3 +221,11 @@ See [test/kernel](../test/kernel/README.md)
 
 - [Render Framework](./render.md)
 - [Reducer Architecture Overview](./reducer/architecture.md)
+
+## Where to Get Help? ##
+
+You can connect with us in our [slack channel](https://cloud-native.slack.com/archives/C02AB15583A).
+
+The OpenTelemetry eBPF special interest group (SIG) meets regularly, and the meetting is held every 
+week on Tuesday at 09:00 Pacific time.
+See the [eBPF Workgroup Meeting Notes](https://docs.google.com/document/d/13GK915hdDQ9sUYzUIWi4pOfJK68EE935ugutUgL3yOw) for a summary description of past meetings.


### PR DESCRIPTION
**Description:** adding a mention of the SIG meeting in the CONTRIBUTING.md and README.md files of the SIG meeting.
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** close https://github.com/open-telemetry/opentelemetry-ebpf/issues/170

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>