### PR TITLE
Fix build-and-release action: pull build environment

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -57,8 +57,12 @@ jobs:
       - name: Log-in to container registry
         run: |
           docker login --username="$DOCKER_USERNAME" --password-stdin $DOCKER_REGISTRY <<< "$DOCKER_PASSWORD"
+      - name: Fetch build environment
+        run: |
+          docker pull $BENV_IMAGE
       - name: Build artifacts
         run: |
+          echo "github.workspace = ${{ github.workspace }}"
           mkdir -p $GITHUB_WORKSPACE/out
           docker run -t --rm \
             --mount "type=bind,source=/var/run/docker.sock,destination=/var/run/docker.sock" \


### PR DESCRIPTION
**Description:** 
Fixed the build-and-release action, used to release containers and packages.

There was a missing `docker pull` for the build image.

**Testing:**
Performed a dry-run of the build-and-release action. It was successful.

This did not test the `docker push` component (since it was a dry run), but that part should not be affected. Ideally will have a  review before a non-dry run.
