### PR TITLE
Handle Pods owned by a CronJob

### DIFF
--- a/collector/k8s/collector.proto
+++ b/collector/k8s/collector.proto
@@ -13,6 +13,7 @@ message Info {
   enum Type {
     K8S_REPLICASET = 0;
     K8S_POD = 1;
+    K8S_JOB = 2;
   }
 
   Type type = 1;
@@ -27,6 +28,7 @@ message Info {
 
   PodInfo pod_info = 3;
   ReplicaSetInfo rs_info = 4;
+  JobInfo job_info = 5;
 }
 
 message Response {

--- a/collector/k8s/kubernetes_info.proto
+++ b/collector/k8s/kubernetes_info.proto
@@ -36,3 +36,9 @@ message ReplicaSetInfo {
 
   OwnerInfo owner = 2;
 }
+
+message JobInfo {
+  string uid = 1;
+
+  OwnerInfo owner = 2;
+}

--- a/collector/k8s/kubernetes_owner_kind.cc
+++ b/collector/k8s/kubernetes_owner_kind.cc
@@ -8,6 +8,8 @@ namespace collector {
 namespace {
 static constexpr char REPLICA_SET_KIND[] = "ReplicaSet";
 static constexpr char DEPLOYMENT_KIND[] = "Deployment";
+static constexpr char JOB_KIND[] = "Job";
+static constexpr char CRONJOB_KIND[] = "CronJob";
 static constexpr char NO_OWNER_KIND[] = "NoOwner";
 static constexpr char OTHER_KIND[] = "Other";
 } // namespace
@@ -20,6 +22,14 @@ KubernetesOwnerKind KubernetesOwnerKindFromString(const std::string &str)
 
   if (str == DEPLOYMENT_KIND) {
     return KubernetesOwnerKind::Deployment;
+  }
+
+  if (str == JOB_KIND) {
+    return KubernetesOwnerKind::Job;
+  }
+
+  if (str == CRONJOB_KIND) {
+    return KubernetesOwnerKind::CronJob;
   }
 
   if (str == NO_OWNER_KIND) {
@@ -36,6 +46,10 @@ const char *KubernetesOwnerKindToString(const KubernetesOwnerKind kind)
     return REPLICA_SET_KIND;
   case KubernetesOwnerKind::Deployment:
     return DEPLOYMENT_KIND;
+  case KubernetesOwnerKind::Job:
+    return JOB_KIND;
+  case KubernetesOwnerKind::CronJob:
+    return CRONJOB_KIND;
   case KubernetesOwnerKind::NoOwner:
     return NO_OWNER_KIND;
 
@@ -52,6 +66,16 @@ bool KubernetesOwnerIsDeployment(const std::string &str)
 bool KubernetesOwnerIsReplicaSet(const std::string &str)
 {
   return str == REPLICA_SET_KIND;
+}
+
+bool KubernetesOwnerIsJob(const std::string &str)
+{
+  return str == JOB_KIND;
+}
+
+bool KubernetesOwnerIsCronJob(const std::string &str)
+{
+  return str == CRONJOB_KIND;
 }
 
 bool KubernetesOwnerIsNoOwner(const std::string &str)

--- a/collector/k8s/kubernetes_owner_kind.h
+++ b/collector/k8s/kubernetes_owner_kind.h
@@ -12,6 +12,8 @@ namespace collector {
 enum class KubernetesOwnerKind : u8 {
   ReplicaSet = 0,
   Deployment = 1,
+  Job = 2,
+  CronJob = 3,
   // TODO: fill in more as we go.
   //
   NoOwner = 254,
@@ -23,6 +25,8 @@ const char *KubernetesOwnerKindToString(const KubernetesOwnerKind kind);
 
 bool KubernetesOwnerIsDeployment(const std::string &str);
 bool KubernetesOwnerIsReplicaSet(const std::string &str);
+bool KubernetesOwnerIsJob(const std::string &str);
+bool KubernetesOwnerIsCronJob(const std::string &str);
 bool KubernetesOwnerIsNoOwner(const std::string &str);
 
 } // namespace collector


### PR DESCRIPTION
**Description:**  The pods created by the CronJob are currently being inaccurately attributed to an intermediate Job as their owner.  This patch corrects this by properly associating the CronJob as the actual owner of those pods.

**Testing:** 
1. CronJob
```
$ kubectl create cronjob cronjob1 --image=busybx --schedule="*/1 * * * *" -- sleep 20

$ kubectl get pods cronjob1-28413736-bpz85 -o json | jq -r '.metadata.ownerReferences'
[
  {
    "apiVersion": "batch/v1",
    "blockOwnerDeletion": true,
    "controller": true,
    "kind": "Job",
    "name": "cronjob1-28413736",
    "uid": "e25ce59b-1069-4775-99e6-a656b6aa448d"
  }
]

$ kubectl get jobs cronjob1-28413736 -o json | jq -r '.metadata.ownerReferences'
[
  {
    "apiVersion": "batch/v1",
    "blockOwnerDeletion": true,
    "controller": true,
    "kind": "CronJob",
    "name": "cronjob1",
    "uid": "07d02c09-ab5d-4f13-9d1b-fb2940ea27f0"
  }
]

k8s-relay logs:

2024-01-09 18:15:03.247431+00:00 trace [p:7 t:16] Merged pod into internal state: uid: "7dbf8dbf-502d-40cc-baa1-922ca643281d"
ip: "10.1.235.207"
owner {
  uid: "937cfa1e-758a-4cf7-9156-d0771d790031"
  name: "cronjob1-28413735"
  kind: "Job"
}
ns: "default"
name: "cronjob1-28413735-rrnf6"
version: "\'busybx\'"
container_infos {
  name: "cronjob1"
  image: "busybx"
}

2024-01-09 18:15:03.247460+00:00 trace [p:7 t:16] Pod's owner Job has CronJob owner. Sending pod with owner uid: "07d02c09-ab5d-4f13-9d1b-fb2940ea27f0"
name: "cronjob1"
kind: "CronJob"
```
2. Regular Job
```
$ kubectl create job test-job --image=busybox -- sleep 1000

$ kubectl get pods test-job-6p7bt -o json | jq -r '.metadata.ownerReferences'
[
  {
    "apiVersion": "batch/v1",
    "blockOwnerDeletion": true,
    "controller": true,
    "kind": "Job",
    "name": "test-job",
    "uid": "95422620-bd34-43b2-acb4-f6cfd542fb96"
  }
]

$ kubectl get jobs test-job -o json | jq -r '.metadata.ownerReferences'
null

k8s-relay logs:

2024-01-09 01:47:52.133522+00:00 trace [p:7 t:15] Adding pod into internal state: uid: "412d8074-6059-4488-9e4e-3ec122975d2a"
ip: "10.1.36.127"
owner {
  uid: "95422620-bd34-43b2-acb4-f6cfd542fb96"
  name: "test-job"
  kind: "Job"
}
ns: "default"
name: "test-job-6p7bt"
version: "\'docker.io/library/busybox:latest\'"
container_infos {
  id: "containerd://5ae7c37d4b2e86cc6b9f9cd9b6263247e9d38db9d9fbf671a9eb80753635424b"
  name: "test-job"
  image: "docker.io/library/busybox:latest"
}

2024-01-09 01:47:52.133528+00:00 trace [p:7 t:15] Pod's owner Job has non-CronJob owner. Sending pod with owner uid: "95422620-bd34-43b2-acb4-f6cfd542fb96"
name: "test-job"
kind: "Job"

```

**Documentation:** None