### PR TITLE
bump patch version number for v0.10.2

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -10,7 +10,7 @@ set -e
 # of perceived trust in an implementation -- please discuss before bumping these.
 export EBPF_NET_MAJOR_VERSION='0'
 export EBPF_NET_MINOR_VERSION='10'
-export EBPF_NET_PATCH_VERSION='1'
+export EBPF_NET_PATCH_VERSION='2'
 
 # -----
 # Build number is incremented automatically, so we can release directly from


### PR DESCRIPTION
ahead of release. These numbers are embedded in compiled binaries and output in logs.