### PR TITLE
Enable full DNS names

### DIFF
--- a/collector/kernel/buffered_poller.cc
+++ b/collector/kernel/buffered_poller.cc
@@ -414,7 +414,7 @@ void BufferedPoller::handle_dns_message(message_metadata const &metadata, jb_age
 
     send_a_aaaa_response = 1;
     // truncate hostname */
-    sent_hostname_len = (hostname_len < MAX_ENCODED_DOMAIN_NAME) ? (u16)hostname_len : MAX_ENCODED_DOMAIN_NAME;
+    sent_hostname_len = (hostname_len < DNS_NAME_MAX_LENGTH) ? (u16)hostname_len : DNS_NAME_MAX_LENGTH;
     sent_hostname = hostname_out + hostname_len - sent_hostname_len;
   }
 
@@ -534,7 +534,7 @@ void BufferedPoller::timeout_dns_request(u64 timestamp_ns, const DnsRequests::Re
     const char *hostname_out = req->first.name.c_str();
     size_t hostname_len = req->first.name.size();
 
-    u16 sent_hostname_len = (hostname_len < MAX_ENCODED_DOMAIN_NAME) ? (u16)hostname_len : MAX_ENCODED_DOMAIN_NAME;
+    u16 sent_hostname_len = (hostname_len < DNS_NAME_MAX_LENGTH) ? (u16)hostname_len : DNS_NAME_MAX_LENGTH;
 
     const char *sent_hostname = hostname_out + hostname_len - sent_hostname_len;
 

--- a/collector/kernel/dns/dns.h
+++ b/collector/kernel/dns/dns.h
@@ -13,12 +13,11 @@ extern "C" {
 
 #define DNS_NAME_MAX_LENGTH 256
 
-#define MAX_ENCODED_DOMAIN_NAME 80
 #define MAX_ENCODED_IP_ADDRS 16
 
 #define MAX_ENCODED_DNS_MESSAGE                                                                                                \
   (/* timestamp */ sizeof(u64) + /* jb message */ jb_ingest__dns_response__data_size +                                         \
-   /* ip addrs */ (sizeof(u32) * MAX_ENCODED_IP_ADDRS) + /* DNS name */ MAX_ENCODED_DOMAIN_NAME)
+   /* ip addrs */ (sizeof(u32) * MAX_ENCODED_IP_ADDRS) + /* DNS name */ DNS_NAME_MAX_LENGTH)
 
 int dns_name_length(const unsigned char *encoded, const unsigned char *abuf, int alen);
 

--- a/reducer/dns_cache.h
+++ b/reducer/dns_cache.h
@@ -17,7 +17,7 @@ namespace reducer {
 namespace dns {
 struct hash_ipv6_address;
 struct eq_ipv6_address;
-static constexpr u32 max_len = 80;
+static constexpr u32 max_len = 256;
 typedef short_string<max_len> dns_record;
 } // namespace dns
 

--- a/render/ebpf_net.render
+++ b/render/ebpf_net.render
@@ -1041,7 +1041,7 @@ app ingest {
       description "DNS A/AAAA record query response, with name, response address(es), and latency information"
       severity 0
       1: u32 sk_id
-      2: u16 total_dn_len                 // Total length of domain name without truncation (MAX_ENCODED_DOMAIN_NAME)
+      2: u16 total_dn_len                 // Total length of domain name without truncation (DNS_NAME_MAX_LENGTH)
       3: string domain_name               // Domain name being queried (possibly truncated)
       4: string ipv4_addrs                // IPv4 addresses corresponding to domain name 'dn'
       5: string ipv6_addrs                // IPv6 addresses corresponding to domain name 'dn'
@@ -1051,7 +1051,7 @@ app ingest {
       description "A DNS A/AAAA record request timeout"
       severity 0
       1: u32 sk_id
-      2: u16 total_dn_len                 // Total length of domain name without truncation (MAX_ENCODED_DOMAIN_NAME)
+      2: u16 total_dn_len                 // Total length of domain name without truncation (DNS_NAME_MAX_LENGTH)
       3: string domain_name               // Domain name being queried (possibly truncated)
       4: u64 timeout_ns                   // Timeout duration for request (in ns)
     }
@@ -1065,7 +1065,7 @@ app ingest {
       description "DNS A/AAAA record query response, with name, response address(es), and latency information, with direction"
       severity 0
       1: u32 sk_id
-      2: u16 total_dn_len                 // Total length of domain name without truncation (MAX_ENCODED_DOMAIN_NAME)
+      2: u16 total_dn_len                 // Total length of domain name without truncation (DNS_NAME_MAX_LENGTH)
       3: string domain_name               // Domain name being queried (possibly truncated)
       4: string ipv4_addrs                // IPv4 addresses corresponding to domain name 'dn'
       5: string ipv6_addrs                // IPv6 addresses corresponding to domain name 'dn'


### PR DESCRIPTION
**Description:** The limit for DNS hostnames being sent to the reducer increased from 80 characters to the full 256, as according to RFC 1035.
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-network/issues/256

**Testing:** automatic tests

**Documentation:** none