### PR TITLE
support fedora in kernel header install script

### DIFF
--- a/collector/kernel/kernel_headers.sh
+++ b/collector/kernel/kernel_headers.sh
@@ -56,7 +56,7 @@ function detect_distro {
   if [[ -e "${os_release_file}" ]]; then
     os_id="$(grep '^ID=' "${os_release_file}" 2> /dev/null | sed -e 's/ID=\(.*\)/\1/g' -e 's/"//g')"
     case "${os_id}" in
-      debian | ubuntu | centos | amazon | rhel)
+      debian | ubuntu | centos | amazon | rhel | fedora)
         echo "${os_id}"
         return
         ;;
@@ -80,6 +80,9 @@ function detect_distro {
       echo "rhel"
       return
     elif grep 'Amazon Linux' "${system_release_file}" > /dev/null 2> /dev/null; then
+      echo "amazon"
+      return
+    elif grep 'Fedora' "${system_release_file}" > /dev/null 2> /dev/null; then
       echo "amazon"
       return
     fi


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fixes https://github.com/open-telemetry/opentelemetry-network/issues/261 by supporting fedora in the kernel header install script

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-network/issues/261

**Testing:** <Describe what testing was performed and which tests were added.>

Working on manual testing, currently stuck trying to build `opentelemetry-ebpf-build-tools` because it "freezes" on `Cloning into '/home/tristan/Devel/opentelemetry-ebpf-build-tools/gcp_cpp/google-cloud-cpp'...`

I was also going to add to the CI tests but was getting confused hoping around shell scripts. If anyone can help explain what needs to be updated there I'd be happy to add fedora to the distros tested against if its desired.

**Documentation:** <Describe the documentation added.>

None. It doesn't appear there are any docs about what hosts are supported, so if wanted I can add a list of supported distros to https://github.com/open-telemetry/opentelemetry-network/blob/main/docs/kernel-collector.md, not sure if anywhere else would be appropriate to add that info?