### PR TITLE
fix reducer wrong example of enable-metrics and disable-metrics

### DIFF
--- a/dist/reducer/reducer.yaml
+++ b/dist/reducer/reducer.yaml
@@ -2,7 +2,7 @@
 telemetry_port: 8000
 
 # How many ingest shards to run.
-num_aggregation_shards: 1
+num_ingest_shards: 1
 
 # How many matching shards to run.
 num_matching_shards: 1
@@ -80,13 +80,13 @@ enable_percentile_latencies: false
 # A metric group can also be disabled. To do so, specify '<group>.all', where <group> is one of: tcp,udp,dns,http.
 # A value of 'none' can be given to enable all metrics.
 # If this argument is not specified, the recommended collection of metrics will be used.
-# Example: 'http.all;dns.all;udp.drops'. This will disable all http metrics, all dns metrics, and the udp.drops metric.
+# Example: 'http.all,dns.all,udp.drops'. This will disable all http metrics, all dns metrics, and the udp.drops metric.
 #disable_metrics: ""
 
 # Comma-separated list of metrics to enable.
 # This list is processed AFTER disable-metrics.
 # A metric group can also be enabled. To do so, specify '<group>.all', where <group> is one of: tcp,udp,dns,http.
-# Example: 'http.all;dns.all;udp.drops'. This will enable all http metrics, all dns metrics, and the udp.drops metric.
+# Example: 'http.all,dns.all,udp.drops'. This will enable all http metrics, all dns metrics, and the udp.drops metric.
 #enable_metrics: ""
 
 # Interval (in seconds) to generate a JSON dump of the span indexes for each core.

--- a/reducer/main.cc
+++ b/reducer/main.cc
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
       "A metric group can also be disabled. To do so, specify '<group>.all', where <group> is one of: tcp,udp,dns,http.\n"
       "A value of 'none' can be given to enable all metrics.\n\n"
       "If this argument is not specified, the recommended collection of metrics will be used.\n\n"
-      "Example: disable-metrics=http.all;dns.all;udp.drops\n"
+      "Example: disable-metrics=http.all,dns.all,udp.drops\n"
       "This example will disable all http metrics, all dns metrics, and the udp.drops metric.",
       {"disable-metrics"});
 
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
       "enable-metrics",
       "A comma (,) separated list of metrics to enable.  This list is processed AFTER disable-metrics\n"
       "A metric group can also be enabled. To do so, specify '<group>.all', where <group> is one of: tcp,udp,dns,http.\n"
-      "Example: enable-metrics=http.all;dns.all;udp.drops\n"
+      "Example: enable-metrics=http.all,dns.all,udp.drops\n"
       "This example will enable all http metrics, all dns metrics, and the udp.drops metric.",
       {"enable-metrics"});
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The example of enable-metrics and disable-metrics is wrong. The command line prompts need to be separated by commas, but the example uses semicolons.
**Link to tracking Issue:** <Issue number if applicable>
#280 
**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>