### PR TITLE
Fix clang formatting in #286

### DIFF
--- a/collector/kernel/bpf_src/render_bpf.h
+++ b/collector/kernel/bpf_src/render_bpf.h
@@ -11,7 +11,7 @@
 
 ///////// render_bpf.c config
 
-#define BPF_MAX_CPUS 1024              // Maximum number of CPUs to support
+#define BPF_MAX_CPUS 1024             // Maximum number of CPUs to support
 #define TABLE_SIZE__TGID_INFO MAX_PID // Task (TGID) information
 #define TABLE_SIZE__SEEN_INODES                                                                                                \
   70000 // XXX: Is this even necessary? could this tracking be done in userland with non-limited tables?

--- a/reducer/ingest/tcp_server.h
+++ b/reducer/ingest/tcp_server.h
@@ -5,11 +5,10 @@
 
 #pragma once
 
+#include "absl/base/thread_annotations.h"
 #include <reducer/ingest/ingest_worker.h>
 #include <reducer/load_balancer.h>
 #include <reducer/prometheus_handler.h>
-#include "absl/base/thread_annotations.h"
-
 
 #include <generated/ebpf_net/ingest/index.h>
 

--- a/reducer/load_balancer.h
+++ b/reducer/load_balancer.h
@@ -7,9 +7,9 @@
 
 #include <set>
 
+#include "absl/base/thread_annotations.h"
 #include <absl/container/flat_hash_map.h>
 #include <absl/synchronization/mutex.h>
-#include "absl/base/thread_annotations.h"
 
 #include <absl/types/span.h>
 

--- a/reducer/worker.h
+++ b/reducer/worker.h
@@ -8,10 +8,10 @@
 #include "channel/callbacks.h"
 #include "channel/tcp_channel.h"
 
+#include "absl/base/thread_annotations.h"
 #include <absl/container/node_hash_map.h>
 #include <absl/synchronization/mutex.h>
 #include <absl/synchronization/notification.h>
-#include "absl/base/thread_annotations.h"
 
 #include <uv.h>
 


### PR DESCRIPTION
PR #286 introduced some edits that do not pass clang-format-11. This fixes those files.