### PR TITLE
Update build image in build-and-test CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,7 +11,7 @@ on:
     paths:
 
 env:
-  BENV_IMAGE: public.ecr.aws/u7d6c4a3/solarwinds-opentelemetry-network:benv-exp 
+  BENV_IMAGE: docker.io/otel/opentelemetry-network-build-tools
 
 concurrency:
   group: build-and-test-${{ github.event.pull_request_number || github.ref }}


### PR DESCRIPTION
we previously only changed the build-and-release workflow to use the container image generated by opentelemetry-network-build-tools. This also changes the build-and-test workflow.
