### PR TITLE
build: rename shell variable in clang-format scripts for better readability

### DIFF
--- a/.github/workflows/scripts/check-clang-format.sh
+++ b/.github/workflows/scripts/check-clang-format.sh
@@ -3,15 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-CLANG_FORMAT_VERSION="clang-format"
-if ! command -v ${CLANG_FORMAT_VERSION}
+CLANG_FORMAT="clang-format"
+if ! command -v ${CLANG_FORMAT}
 then
-  echo "ERROR: requires ${CLANG_FORMAT_VERSION}"
+  echo "ERROR: requires ${CLANG_FORMAT}"
   exit 1
 fi
 
 RC=0
-CMD="${CLANG_FORMAT_VERSION} -Werror --dry-run -style=file"
+CMD="${CLANG_FORMAT} -Werror --dry-run -style=file"
 function check_file
 {
   if ! ${CMD} $1

--- a/clang-format.sh
+++ b/clang-format.sh
@@ -3,15 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-CLANG_FORMAT_VERSION="clang-format"
-if ! command -v ${CLANG_FORMAT_VERSION}
+CLANG_FORMAT="clang-format"
+if ! command -v ${CLANG_FORMAT}
 then
-  echo "ERROR: requires ${CLANG_FORMAT_VERSION}"
+  echo "ERROR: requires ${CLANG_FORMAT}"
   exit 1
 fi
 
 RC=0
-CMD="${CLANG_FORMAT_VERSION} -Werror -i -style=file"
+CMD="${CLANG_FORMAT} -Werror -i -style=file"
 function format_file
 {
   if ! ${CMD} $1


### PR DESCRIPTION
found by @bjandras
