### PR TITLE
fix(ci): correctly pull containers from container builds in build-and-test.yaml

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -87,6 +87,7 @@ jobs:
         
         # Export reducer container
         mkdir -p container-exports
+        docker pull localhost:5000/reducer
         docker save localhost:5000/reducer > container-exports/reducer.tar
         
         # Clean up registry
@@ -134,6 +135,7 @@ jobs:
         
         # Export kernel-collector container
         mkdir -p container-exports
+        docker pull localhost:5000/kernel-collector
         docker save localhost:5000/kernel-collector > container-exports/kernel-collector.tar
         
         # Clean up registry
@@ -181,6 +183,7 @@ jobs:
         
         # Export kernel-collector-test container
         mkdir -p container-exports
+        docker pull localhost:5000/kernel-collector-test
         docker save localhost:5000/kernel-collector-test > container-exports/kernel-collector-test.tar
         
         # Clean up registry

--- a/dev/docker-registry-push.sh
+++ b/dev/docker-registry-push.sh
@@ -50,6 +50,7 @@ if [[ "${do_login}" == true ]]; then
 fi
 
 # add --tls-verify=false for default registry (localhost:5000)
+push_args=""
 if [[ "${docker_registry}" == "localhost:5000" ]]; then
   push_args="--tls-verify=false"
 else

--- a/dev/docker-registry-push.sh
+++ b/dev/docker-registry-push.sh
@@ -53,8 +53,6 @@ fi
 push_args=""
 if [[ "${docker_registry}" == "localhost:5000" ]]; then
   push_args="--tls-verify=false"
-else
-  push_args=""
 fi
 
 (set -x; \

--- a/dev/docker-registry-push.sh
+++ b/dev/docker-registry-push.sh
@@ -49,8 +49,15 @@ if [[ "${do_login}" == true ]]; then
   "${EBPF_NET_SRC_ROOT}/dev/docker-registry-login.sh" "${login_args}" "${docker_registry}"
 fi
 
+# add --tls-verify=false for default registry (localhost:5000)
+if [[ "${docker_registry}" == "localhost:5000" ]]; then
+  push_args="--tls-verify=false"
+else
+  push_args=""
+fi
+
 (set -x; \
   podman tag "${image_name}:${image_tag}" \
     "${docker_registry}/${image_name}:${image_tag}"; \
-  podman push "${docker_registry}/${image_name}:${image_tag}"; \
+  podman push ${push_args} "${docker_registry}/${image_name}:${image_tag}"; \
 )


### PR DESCRIPTION
**Description:** a recent PR changed the build to use podman. Another recent PR built and saved container artifacts for testing. The two interacted and needed a fix to allow HTTP registries and to pull from the temporary registry being spun up.