### PR TITLE
fix(nat): add nat existing kprobe with exported symbol

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -415,8 +415,8 @@ jobs:
             collector_logs=$(docker logs $container_id 2>&1 || true)
             echo "$collector_logs"
             
-            # Check for error strings in the logs
-            if echo "$collector_logs" | grep -i "error" > /dev/null 2>&1; then
+            # Check for error strings in the logs (exclude GCP metadata fetch errors which are expected)
+            if echo "$collector_logs" | grep -i "error" | grep -v "Unable to fetch GCP metadata: error while fetching Google Cloud Platform instance metadata" > /dev/null 2>&1; then
               echo "✗ Found 'error' in kernel collector output - test failed"
               docker stop $container_id || true
               docker rm $container_id || true

--- a/collector/kernel/bpf_src/render_bpf.c
+++ b/collector/kernel/bpf_src/render_bpf.c
@@ -2784,29 +2784,6 @@ int on_ctnetlink_dump_tuples(struct pt_regs *ctx)
   return 0;
 }
 
-SEC("kprobe/ctnetlink_fill_info")
-int on_ctnetlink_fill_info(struct pt_regs *ctx)
-{
-  struct sk_buff *skb = (struct sk_buff *)PT_REGS_PARM1(ctx);
-  struct nf_conn *ct = (struct nf_conn *)PT_REGS_PARM5(ctx);
-
-  if (!ct) {
-    return 0;
-  }
-
-  u64 ct_addr = (u64)ct;
-
-  // Submit for original direction (dir=0)
-  const struct nf_conntrack_tuple *orig_tuple = &ct->tuplehash[0].tuple;
-  submit_conntrack_tuple(ctx, orig_tuple, ct_addr, 0);
-
-  // Submit for reply direction (dir=1)
-  const struct nf_conntrack_tuple *reply_tuple = &ct->tuplehash[1].tuple;
-  submit_conntrack_tuple(ctx, reply_tuple, ct_addr, 1);
-
-  return 0;
-}
-
 //
 // Include other modules
 //

--- a/collector/kernel/bpf_src/render_bpf.c
+++ b/collector/kernel/bpf_src/render_bpf.c
@@ -2728,37 +2728,6 @@ int on_nf_conntrack_alter_reply(struct pt_regs *ctx)
   return 0;
 }
 
-static __always_inline void
-submit_conntrack_tuple(struct pt_regs *ctx, const struct nf_conntrack_tuple *tuple, u64 ct_addr, u8 dir)
-{
-  u64 now = get_timestamp();
-
-  if (dir == 0) {
-    perf_submit_agent_internal__existing_conntrack_tuple(
-        ctx,
-        now,
-        ct_addr,
-        (u32)BPF_CORE_READ(tuple, src.u3.ip),
-        (u16)BPF_CORE_READ(tuple, src.u.all),
-        (u32)BPF_CORE_READ(tuple, dst.u3.ip),
-        (u16)BPF_CORE_READ(tuple, dst.u.all),
-        (u8)BPF_CORE_READ(tuple, dst.protonum),
-        dir);
-  } else {
-    // NOTE: in the dir=1 case, we flip src/dst to preserve four-tuple order.
-    perf_submit_agent_internal__existing_conntrack_tuple(
-        ctx,
-        now,
-        ct_addr,
-        (u32)BPF_CORE_READ(tuple, dst.u3.ip),
-        (u16)BPF_CORE_READ(tuple, dst.u.all),
-        (u32)BPF_CORE_READ(tuple, src.u3.ip),
-        (u16)BPF_CORE_READ(tuple, src.u.all),
-        (u8)BPF_CORE_READ(tuple, dst.protonum),
-        dir);
-  }
-}
-
 SEC("kprobe/ctnetlink_dump_tuples")
 int on_ctnetlink_dump_tuples(struct pt_regs *ctx)
 {
@@ -2769,18 +2738,40 @@ int on_ctnetlink_dump_tuples(struct pt_regs *ctx)
     return 0;
   }
 
+  u64 now = get_timestamp();
+
   // "struct nf_conn" contains two "struct nf_conntrack_tuple_hash". On the
   // dir=1 case, we want to report the addr of the dir=0, which we expected to
   // see first. this is addr is sizeof(struct nf_conntrack_tuple_hash) ahead of
   // the start of our current "ct"
   u64 ct_addr = (u64)ct;
+
   u8 dir = BPF_CORE_READ(ct, dst.dir);
-
-  if (dir == 1) {
+  if (dir == 0) {
+    perf_submit_agent_internal__existing_conntrack_tuple(
+        ctx,
+        now,
+        (u64)ct_addr,
+        (u32)BPF_CORE_READ(ct, src.u3.ip),
+        (u16)BPF_CORE_READ(ct, src.u.all),
+        (u32)BPF_CORE_READ(ct, dst.u3.ip),
+        (u16)BPF_CORE_READ(ct, dst.u.all),
+        (u8)BPF_CORE_READ(ct, dst.protonum),
+        (u8)dir);
+  } else {
     ct_addr = ct_addr - sizeof(struct nf_conntrack_tuple_hash);
+    // NOTE: in the dir=1 case, we flip src/dst to preserve four-tuple order.
+    perf_submit_agent_internal__existing_conntrack_tuple(
+        ctx,
+        now,
+        (u64)ct_addr,
+        (u32)BPF_CORE_READ(ct, dst.u3.ip),
+        (u16)BPF_CORE_READ(ct, dst.u.all),
+        (u32)BPF_CORE_READ(ct, src.u3.ip),
+        (u16)BPF_CORE_READ(ct, src.u.all),
+        (u8)BPF_CORE_READ(ct, dst.protonum),
+        (u8)dir);
   }
-
-  submit_conntrack_tuple(ctx, ct, ct_addr, dir);
   return 0;
 }
 

--- a/collector/kernel/nat_prober.cc
+++ b/collector/kernel/nat_prober.cc
@@ -27,13 +27,15 @@ NatProber::NatProber(ProbeHandler &probe_handler, struct render_bpf_bpf *skel, s
 
   // EXISTING
   ProbeAlternatives probe_alternatives{
-      "ctnetlink_dump_tuples",
+      "ctnetlink_existing_conntrack",
       {
+          // ctnetlink_fill_info is more widely available as it calls ctnetlink_dump_tuples twice
+          {"on_ctnetlink_fill_info", "ctnetlink_fill_info"},
           {"on_ctnetlink_dump_tuples", "ctnetlink_dump_tuples"},
           // Attaching probe to ctnetlink_dump_tuples fails on some distros and kernel builds, for example Ubuntu Jammy.
           {"on_ctnetlink_dump_tuples", "ctnetlink_dump_tuples_ip"},
       }};
-  std::string ctnetlink_dump_tuples_k_func_name = probe_handler.start_probe(skel, probe_alternatives);
+  std::string ctnetlink_existing_k_func_name = probe_handler.start_probe(skel, probe_alternatives);
 
   periodic_cb();
   int res = query_kernel();
@@ -50,7 +52,7 @@ NatProber::NatProber(ProbeHandler &probe_handler, struct render_bpf_bpf *skel, s
   periodic_cb();
 
   // Cleanup existing
-  probe_handler.cleanup_probe(ctnetlink_dump_tuples_k_func_name);
+  probe_handler.cleanup_probe(ctnetlink_existing_k_func_name);
   periodic_cb();
 }
 

--- a/collector/kernel/nat_prober.cc
+++ b/collector/kernel/nat_prober.cc
@@ -29,8 +29,8 @@ NatProber::NatProber(ProbeHandler &probe_handler, struct render_bpf_bpf *skel, s
   ProbeAlternatives probe_alternatives{
       "ctnetlink_existing_conntrack",
       {
-          // ctnetlink_fill_info is more widely available as it calls ctnetlink_dump_tuples twice
-          {"on_ctnetlink_fill_info", "ctnetlink_fill_info"},
+          // nf_ct_port_tuple_to_nlattr is more widely available and has the same parameters as ctnetlink_dump_tuples
+          {"on_ctnetlink_dump_tuples", "nf_ct_port_tuple_to_nlattr"},
           {"on_ctnetlink_dump_tuples", "ctnetlink_dump_tuples"},
           // Attaching probe to ctnetlink_dump_tuples fails on some distros and kernel builds, for example Ubuntu Jammy.
           {"on_ctnetlink_dump_tuples", "ctnetlink_dump_tuples_ip"},


### PR DESCRIPTION
**Description:** the collector's EXISTING NAT kprobes were on static functions that did not get published in /proc/kallsyms on every compiled kernel, so these kernels failed to load NAT. Here we switch to a function `nf_ct_port_tuple_to_nlattr` that is exported on kernels as early as 4.20 (maybe before, didn't check).

This fixes the simple tests (not the deeper tests alas) on 4 of the 6 tested kernels. 