### PR TITLE
fix(kernel-collector): Support AWS IMDSv2 with IMDSv1 fallback

### DIFF
--- a/util/aws_instance_metadata.h
+++ b/util/aws_instance_metadata.h
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <list>
 #include <map>
 #include <set>
 #include <stdexcept>
@@ -136,9 +137,15 @@ private:
    * @assumes curl_global_init() was called!
    *
    * @param keys_to_endpoints: a map of <key> to <endpoint>
+   * @param imdsv2_token: optional IMDSv2 token for authenticated requests
    * @result: a map of <key> to <result> of a curl to the corresponding endpoint
    */
-  FetchResult fetch(std::map<std::string, std::string> keys_to_endpoints);
+  FetchResult fetch(std::map<std::string, std::string> keys_to_endpoints, const std::string &imdsv2_token = "");
+
+  /**
+   * Try to fetch an IMDSv2 token. Returns empty string on failure.
+   */
+  std::string fetch_imdsv2_token();
 
   std::chrono::microseconds timeout_;
   AwsMetadataValue id_;


### PR DESCRIPTION
## Description:
The kernel-collector currently fails to retrieve instance metadata on modern AWS EC2 instances where IMDSv1 is disabled by default. This makes the collector non-functional in a standard, secure AWS environment.

This fix introduces support for AWS IMDSv2 while maintaining backward compatibility with IMDSv1.

The implementation follows this logic:

A short-lived (2-second timeout) PUT request is made to the IMDSv2 token endpoint to fetch a session token.

If a token is successfully retrieved, it is used in the X-aws-ec2-metadata-token header for all subsequent metadata requests, which are directed to the IMDSv2 /latest/ endpoints.

If the token request fails (due to timeout, network error, or IMDSv1-only environment), the system gracefully falls back to the original IMDSv1 behavior, making requests without the token to the /2016-09-02/ endpoints.

Link to tracking Issue:
Fixes #356 

## Testing:
DISCLAIMER: Full end-to-end testing with the kernel collector has not yet been performed. The logic within the util/aws_instance_metadata.cc file has been tested as a standalone unit to confirm the IMDSv2 and fallback mechanisms work as designed.

## Documentation:
No documentation changes are required for this bug fix.