### PR TITLE
Move atoulme to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ For more information about the approver role, see the [community repository](htt
 
 ### Triagers
 
-- [Antoine Toulme](https://github.com/atoulme), Splunk
 - Actively seeking contributors to triage issues
+
+### Emeritus Triagers
+
+- [Antoine Toulme](https://github.com/atoulme), Splunk
 
 For more information about the triager role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).
 


### PR DESCRIPTION
Moving @atoulme to emeritus triager. I have not participated in the project in a long while and don't see this changing in the near future.