### PR TITLE
Update Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,13 +7,19 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["digest", "patch"],
       "schedule": ["before 8am every weekday"]
     },
     {
       "matchUpdateTypes": ["minor", "major"],
       "schedule": ["before 8am on Monday"]
-    }
+    },
+    {
+      groupName: "infra [minor]",
+      matchCategories: ["ci", "docker"],
+      matchUpdateTypes: ["minor"],
+      schedule: ["before 8am on Monday"],
+    },
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
**Description:**
Add more rules to reduce the qty of renovate pr’s and bring down the queue.

key thing is that:

- all minor ci & docker updates are grouped together
- Digest updates are added to the patches pr group